### PR TITLE
Discretize ORB patch orientation

### DIFF
--- a/src/gpu/shaders/keypoints/orb/orb-descriptor.glsl
+++ b/src/gpu/shaders/keypoints/orb/orb-descriptor.glsl
@@ -335,8 +335,12 @@ void main()
 
     // get keypoint data
     float pot = exp2(keypoint.lod);
-    float kcos = cos(keypoint.orientation);
-    float ksin = sin(keypoint.orientation);
+    // discretize orientation into 12-degree steps
+    float degreesOrientation = round(360.0 + degrees(keypoint.orientation)) - 360.0;
+    float orientation = radians(degreesOrientation - mod(degreesOrientation, 12.0));
+
+    float kcos = cos(orientation);
+    float ksin = sin(orientation);
 
     // compute binary descriptor
     // need to run 32 intensity tests for each pixel (32 bits)


### PR DESCRIPTION
In the ORB paper the patch orientation is discretized into 30 steps 12-degree steps. Subjectively it was giving me better results when processing and especially matching live camera feed.

Next step could be adding the missing 29 sets of 256 test pairs coordinates and save sin/cos calculation for each keypoint.
